### PR TITLE
CONFIG_NO_HZ is now CONFIG_NO_HZ_IDLE; test for either.

### DIFF
--- a/NoHzCheck.pm
+++ b/NoHzCheck.pm
@@ -32,11 +32,11 @@ sub executeWithKernelConfig($)
 	my $self = shift;
 	my $kernelConfig = shift;
 
-	if ( $kernelConfig !~ /CONFIG_NO_HZ=y/)
+	if ( $kernelConfig !~ /CONFIG_NO_HZ=y/ && $kernelConfig !~ /CONFIG_NO_HZ_IDLE=y/)
 	{
 		$self->{RESULTKIND} = "not good";
 		$self->{RESULT} = "not found";
-		$self->{COMMENT} = "Try enabling tickless timer support (CONFIG_NO_HZ)\n";
+		$self->{COMMENT} = "Try enabling tickless timer support (CONFIG_NO_HZ_IDLE, or CONFIG_NO_HZ in older kernels)\n";
 			"For more information, see http://wiki.linuxaudio.org/wiki/system_configuration#installing_a_real-time_kernel\n";
 			"http://irc.esben-stien.name/mediawiki/index.php/Setting_Up_Real_Time_Operation_on_GNU/Linux_Systems#Kernel"
 	}


### PR DESCRIPTION
Since Linux 3.8, the preferred name for this option is CONFIG_NO_HZ_IDLE. The old name will likely be removed sooner or later.  
Without this patch, the scan incorrectly tells me that my kernel lacks tickless idle support.
