### PR TITLE
Add missing use statements

### DIFF
--- a/AudioGroupCheck.pm
+++ b/AudioGroupCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package AudioGroupCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/BackgroundCheck.pm
+++ b/BackgroundCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package BackgroundCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/GovernorCheck.pm
+++ b/GovernorCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package GovernorCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/HighResTimersCheck.pm
+++ b/HighResTimersCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package HighResTimersCheck;
 
+use KernelConfigCheck;
 use base qw(KernelConfigCheck);
 
 sub new

--- a/HpetCheck.pm
+++ b/HpetCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package HpetCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/Hz1000Check.pm
+++ b/Hz1000Check.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package Hz1000Check;
 
+use KernelConfigCheck;
 use base qw(KernelConfigCheck);
 
 sub new

--- a/KernelConfigCheck.pm
+++ b/KernelConfigCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package KernelConfigCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/MultiAudioCheck.pm
+++ b/MultiAudioCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package MultiAudioCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/NoAtimeCheck.pm
+++ b/NoAtimeCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package NoAtimeCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/NoHzCheck.pm
+++ b/NoHzCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package NoHzCheck;
 
+use KernelConfigCheck;
 use base qw(KernelConfigCheck);
 
 sub new

--- a/PreemptRtCheck.pm
+++ b/PreemptRtCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package PreemptRtCheck;
 
+use KernelConfigCheck;
 use base qw(KernelConfigCheck);
 
 sub new

--- a/RootCheck.pm
+++ b/RootCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package RootCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/RtcCheck.pm
+++ b/RtcCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package RtcCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/RtprioCheck.pm
+++ b/RtprioCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package RtprioCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/SwappinessCheck.pm
+++ b/SwappinessCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package SwappinessCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/SysCtlCheck.pm
+++ b/SysCtlCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package BackgroundCheck;
 
+use Check;
 use base qw(Check);
 
 sub new

--- a/WatchesCheck.pm
+++ b/WatchesCheck.pm
@@ -17,6 +17,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 package WatchesCheck;
 
+use Check;
 use base qw(Check);
 
 sub new


### PR DESCRIPTION
My perl complains that the base class "Check" is empty, and that the file defining it should be included before "use base". So do that. It makes the program work again.