### PR TITLE
NoAtTimeCheck: Fix typo s/relatime/realtime/.

### DIFF
--- a/NoAtimeCheck.pm
+++ b/NoAtimeCheck.pm
@@ -41,7 +41,7 @@ sub execute
 	{
 		$self->{RESULT} = "$1.$2.$3 kernel";
 		$self->{RESULTKIND} = "good";
-		$self->{COMMENT} = "(relatime is default since 2.6.30)";
+		$self->{COMMENT} = "(realtime is default since 2.6.30)";
 		return;
 	}
 


### PR DESCRIPTION
Fixing small typo in output.