### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Console
 
     git clone git://github.com/raboof/realtimeconfigquickscan.git
     cd realtimeconfigquickscan
-    perl ./realTimeConfigQuickScan.pl
+    perl -I ./ ./realTimeConfigQuickScan.pl
 
 GUI
 ---
@@ -19,7 +19,7 @@ An experimental GUI is now available. To try it:
 
     git clone git://github.com/raboof/realtimeconfigquickscan.git
     cd realtimeconfigquickscan
-    perl ./QuickScan.pl
+    perl -I ./ ./QuickScan.pl
 
 .. and hit 'Start'
 


### PR DESCRIPTION
Updating README file to provide correct launching information, to prevent problems described in [this issue](https://github.com/raboof/realtimeconfigquickscan/issues/8).

The new launching commands add the current directory to @INC. Other ways to include it at runtime are:

Adding these lines to to the top of realTImeConfigQuickScan.pl and QuickScan.pl
```perl
use FindBin;
use lib $FindBin::Bin;
```
Or,

Adding these lines to the top of realTImeConfigQuickScan.pl and QuickScan.pl
```perl
use File::Basename;
use lib dirname (__FILE__);
```
The solution in this pull request was chosen since it is simplest, does not involve modification of the code and it does not make [packaging](https://aur.archlinux.org/packages/realtimeconfigquickscan-git/) any harder.