### PR TITLE
Check for threadirqs option if no rt kernel is found

### DIFF
--- a/AudioGroupCheck.pm
+++ b/AudioGroupCheck.pm
@@ -35,7 +35,7 @@ sub execute
 	{
 		$self->{RESULTKIND} = "not good";
 		$self->{RESULT} = "no";
-		$self->{COMMENT} = "add yourself to the audio group with 'adduser \$USER audio'\n"
+		$self->{COMMENT} = "add yourself to the audio group with 'adduser \$USER audio'"
 	} else {
 		$self->{RESULTKIND} = "good";
 		$self->{RESULT} = "yes";


### PR DESCRIPTION
@raboof and @mxa, hope you don't mind but I had a bit of spare time and loved the idea of this enhancement, so I threw together a PR that fixes #31. 

- After checking for rt kernel, look at `/proc/cmdline` to see if the `threadirqs` kernel parameter was set at boot
- Pull a kernel version checking pattern from [NoAtimeCheck.pm](), because this check is [only valid for kernels>=2.6.39][docs]
- If that's missing as well, include `threadirqs` in 'not good' comment
- Also, link the 'not good' comment to a [slightly different section of the linux audio wiki][docs] where it discusses both options (`threadirqs` and rt-kernel) so user can make an educated decision
- Finally, remove what appears to be an extra newline in [AudioGroupCheck.pm]() because the extra line break in output was annoying me

[docs]: https://wiki.linuxaudio.org/wiki/system_configuration#do_i_really_need_a_real-time_kernel