### PR TITLE
Changed vm.swappiness advice

### DIFF
--- a/SwappinessCheck.pm
+++ b/SwappinessCheck.pm
@@ -49,8 +49,7 @@ sub execute
 		if ($1 > 10)
 		{
 			$self->{COMMENT} = "** vm.swappiness is larger than 10\n" .
-				"set it by adding to /etc/sysctl vm.swappiness=10\n".
-				"See also: http://linuxmusicians.com/viewtopic.php?f=27&t=452&start=30#p8916";
+				"Set swappiness by adding 'vm.swappiness=10' to /etc/sysctl.conf and rebooting\n";
 			$self->{RESULTKIND} = "not good";
 		}
 		else
@@ -58,11 +57,11 @@ sub execute
 			$self->{RESULTKIND} = "good";
 		}
 	}
-#	else
-#	{
-#		$self->{RESULTKIND} = "warning";
-#		print "warning: '/sbin/sysctl vm.swappiness' did not produce a parsable result\n";
-#	}
+	else
+	{
+		$self->{RESULTKIND} = "warning";
+		print "warning: '/sbin/sysctl vm.swappiness' did not produce a parsable result\n";
+	}
 }
 
 1;

--- a/SwappinessCheck.pm
+++ b/SwappinessCheck.pm
@@ -49,7 +49,7 @@ sub execute
 		if ($1 > 10)
 		{
 			$self->{COMMENT} = "** vm.swappiness is larger than 10\n" .
-				"set it with '/sbin/sysctl -w vm.swappiness=10'\n".
+				"set it by adding to /etc/sysctl vm.swappiness=10\n".
 				"See also: http://linuxmusicians.com/viewtopic.php?f=27&t=452&start=30#p8916";
 			$self->{RESULTKIND} = "not good";
 		}
@@ -58,11 +58,11 @@ sub execute
 			$self->{RESULTKIND} = "good";
 		}
 	}
-	else
-	{
-		$self->{RESULTKIND} = "warning";
-		print "warning: '/sbin/sysctl vm.swappiness' did not produce a parsable result\n";
-	}
+#	else
+#	{
+#		$self->{RESULTKIND} = "warning";
+#		print "warning: '/sbin/sysctl vm.swappiness' did not produce a parsable result\n";
+#	}
 }
 
 1;


### PR DESCRIPTION
Changed one line in SwappinessCheck.pm to advise to permanently set swappiness in /etc/sysctl.conf replacing the command which only set it temporarily.
Also commented out the final warning section referring to the old /sbin/sysctl tweak. Does it need anything in its place? Can be removed entirely if not.

Be gentle on me - first time uploading or editing anything on GitHub.